### PR TITLE
Compile with musl libc

### DIFF
--- a/compfile.c
+++ b/compfile.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <string.h>
 
+#include <limits.h>
 #include <stdlib.h>
 #include <sys/signal.h>
 #include <sys/types.h>
@@ -298,7 +299,9 @@ compressfile (int *fdp, char *name, reg Stat *asb, int *cratio) {
       tmpcomp++;
     else
       tmpcomp = name;
-#ifdef MAXNAMLEN	   /* BSD otherwise should be sysV (FFS on sysV?) */
+#ifdef NAME_MAX
+    if (strlen (tmpcomp) + 2 > NAME_MAX)
+#elif MAXNAMLEN	   /* BSD otherwise should be sysV (FFS on sysV?) */
     if (strlen (tmpcomp) + 2 > MAXNAMLEN)
 #else
     if (strlen (tmpcomp) + 2 > DIRSIZ)


### PR DESCRIPTION
musl libc (http://musl-libc.org) does not have MAXNAMLEN nor DIRSIZ, resulting in a compilation failure of compfile.c.