### PR TITLE
afio.c: properly quote argv in promptscript invocation

### DIFF
--- a/afio.c
+++ b/afio.c
@@ -2658,7 +2658,7 @@ next (mode, why)
 	  ttystr=TTY;
 	}
 
-      VOID sprintf(msg,"%s %u %s '%s' <%s",promptscript,arvolume,arspec,why,ttystr);
+      VOID sprintf(msg,"'%s' %u '%s' '%s' <%s",promptscript,arvolume,arspec,why,ttystr);
       for (;;)
       {
 	  auto int result;


### PR DESCRIPTION
Both the promptscript and the next volume script may contain
spaces which require quoting when fed to system().

In our own system, the lack of quoting caused afio to hang
indefinitely, spewing messages about a corrupt archive.
The quoting is still a bit of a hack in that it will explode on
filenames containing single quotes, but it’s less of an issue
since the inputs are under user control proper sanitization can
be put in place beforehand.