### PR TITLE
Remove extraneous parentheses around comparison

### DIFF
--- a/afio.c
+++ b/afio.c
@@ -5239,7 +5239,7 @@ verify (error)
 	      if (nextopen (O_WRONLY) < 0)
 		continue;
 	    }
-	  else if ((answernum == 2) )
+	  else if (answernum == 2)
 	  {
 	      if (system (formatcmd) != 0)
 	      {


### PR DESCRIPTION
Fixes this warning from the clang compiler with Xcode 12.4 on macOS 10.15.7:

```
afio.c:5244:24: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
          else if ((answernum == 2) )
                    ~~~~~~~~~~^~~~
afio.c:5244:24: note: remove extraneous parentheses around the comparison to silence this warning
          else if ((answernum == 2) )
                   ~          ^   ~
afio.c:5244:24: note: use '=' to turn this equality comparison into an assignment
          else if ((answernum == 2) )
                              ^~
                              =
```