### PR TITLE
Support PREFIX and DESTDIR Makefile variables

### DIFF
--- a/INSTALLATION
+++ b/INSTALLATION
@@ -48,11 +48,15 @@ STEP 3. Install the binary and manual page.
 
 Do this manually, or type
 
-make install
+sudo make install
 
-which installs the afio binary in /usr/local/bin, and the manual page
-in /usr/share/man/man1 -- these are the correct locations for most
-Linux systems.
+which installs the afio binary in /usr/local/bin and the manual page in
+/usr/local/share/man/man1 -- these are the correct locations for most
+Linux systems. To install into a prefix other than /usr/local, such as
+/opt/afio, type
+
+sudo make install PREFIX=/opt/afio
+
 
 Notes on using afio
 -------------------

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ CC=gcc
 CFLAGS += $(CFLAGS1) $1 $2 $3 $4 $5 $6 $7 $8 $9 $a $b $c $d $e $(e2) $f $g $I
 LDFLAGS +=
 CPPFLAGS +=
+PREFIX = /usr/local
 
 afio : afio.o compfile.o exten.o match.o $M
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) \
@@ -95,8 +96,8 @@ clean:
 	cd regtest; /bin/sh regtest.clean
 
 install: afio
-	cp afio /usr/local/bin
-	cp afio.1 /usr/share/man/man1
+	cp afio $(DESTDIR)$(PREFIX)/bin
+	cp afio.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 # generate default list of -E extensions from manpage
 # note: on sun, I had to change awk command below to nawk or gawk


### PR DESCRIPTION
Let the user specify PREFIX to indicate where the program and manpage should be installed. This changes the default installation location of the manpage from /usr/share/man/man1 to /usr/local/share/man/man1 but resolves the previous confusion where the program was installed to prefix /usr/local but the manpage was installed to prefix /usr.

By setting DESTDIR a user can stage the installation to a temporary location rather than installing directly to PREFIX.

-----

I chose /usr/local rather than /usr as the default value for PREFIX because /usr is a protected location on some operating systems, such as macOS, into which nobody but the OS vendor can install.

I didn't bother documenting DESTDIR in the installation instructions since it is a standard variable and an advanced feature; if you need this feature, you probably already know about it.

I added sudo to the make install commands in the installation instructions since my experience has been that writing into /usr/local requires root permission.